### PR TITLE
Fix: Remove NEXT_PUBLIC_BASE_PATH from build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,6 @@ jobs:
         run: npm ci
       - name: Build Next.js app
         run: npm run build
-        env:
-          NEXT_PUBLIC_BASE_PATH: /weco-concept-explorer
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Removes the NEXT_PUBLIC_BASE_PATH environment variable from the GitHub Actions workflow file.

The Next.js application is configured with `output: "export"` and has the `basePath` correctly set in `next.config.ts`. According to the Next.js documentation, when using `output: "export"`, the `basePath` should not be set via an environment variable during the build process. This was likely causing the build to fail.