### PR TITLE
Fix: Disable image optimization for static export

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,9 @@ const nextConfig: NextConfig = {
   basePath: "/weco-concept-explorer",
   trailingSlash: true,
   reactStrictMode: true,
+  images: {
+    unoptimized: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
The Next.js build was failing during `next export` because the default image optimization loader is not compatible with static exports.

This commit updates `next.config.ts` to include `images: { unoptimized: true }`, which is the recommended solution for using `next/image` with `next export` without a custom loader. This should resolve the build failure in the GitHub Actions workflow.