### PR TITLE
Fix: Remove basePath from next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
-  basePath: "/weco-concept-explorer",
   trailingSlash: true,
   reactStrictMode: true,
   images: {


### PR DESCRIPTION
I've removed the basePath configuration from next.config.ts. I suspect this was the cause of the GitHub Pages deployment failure, as GitHub Pages typically handles subdirectory serving automatically, and the basePath might conflict with the deployment process when using actions/upload-pages-artifact and actions/deploy-pages.