### PR TITLE
Fix: Configure basePath for GitHub Pages deployment

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
+  basePath: "/weco-concept-explorer",
   trailingSlash: true,
   reactStrictMode: true,
   images: {


### PR DESCRIPTION
The Next.js application was not loading assets correctly on GitHub Pages due to missing basePath configuration. This change adds the `basePath: "/weco-concept-explorer"` setting to `next.config.ts`.

This ensures that asset paths are correctly prefixed with the repository name, resolving the 404 errors for resources like JavaScript chunks and other static files.