### PR TITLE
Fix: Correct related concepts fetching and align graph logic

### DIFF
--- a/components/ConceptGraph.tsx
+++ b/components/ConceptGraph.tsx
@@ -29,18 +29,17 @@ interface ConceptGraphProps {
   currentConceptId: string | null;
 }
 
-// Helper: Get related concepts from a concept object (similar to SPA)
 function getRelatedConcepts(concept: any): Array<{ id: string, label: string, type: string }> {
   const relations: Array<{ id: string, label: string, type: string }> = [];
-  if (!concept || !concept.relatedConcepts) return relations;
-  // The structure of relatedConcepts can vary, ensure it\'s handled robustly
-  // This assumes relatedConcepts is an object where each value is an array of concepts
-  Object.values(concept.relatedConcepts).forEach((group: any) => {
+  if (!concept || !concept.relatedConcepts) return relations; // Check if root concept or its relatedConcepts field is missing
+
+  Object.values(concept.relatedConcepts).forEach((group: any) => { // Iterate over arrays like 'broaderThan', 'relatedTo', 'relatedTopics'
     if (Array.isArray(group)) {
       group.forEach(related => {
-        // Ensure the related concept has an ID and a label to be useful
-        if (related && related.id && related.label && related.type) {
-          relations.push({ id: related.id, label: related.label, type: related.type });
+        // Use related.conceptType for the 'type' field.
+        // Ensure the stub has an id, a label, and a conceptType to be useful.
+        if (related && related.id && related.label && related.conceptType) {
+          relations.push({ id: related.id, label: related.label, type: related.conceptType });
         }
       });
     }


### PR DESCRIPTION
This commit addresses issues in how related concepts were fetched and processed for the concept graph in `components/ConceptGraph.tsx`.

Two main changes were implemented:

1.  Refactored `buildGraphData` to align with SPA example:
    - Modified the function to fetch full data for all direct children of a concept in parallel using `Promise.all`.
    - This ensures nodes are added to the graph with complete data and queued appropriately for exploring further levels (up to 2 jumps).

2.  Corrected `getRelatedConcepts` to use `conceptType`:
    - Updated the function to look for `related.conceptType` instead of `related.type` when extracting concept stubs from the API response.
    - This was a critical fix, as many relations (e.g., in `relatedTopics`) use `conceptType`, and were previously being missed, leading to an incomplete graph.

With these changes, the concept graph now correctly queries, processes, and displays related concepts, including those from fields like `relatedTopics`, up to two levels deep, consistent with the intended functionality.